### PR TITLE
Naming updates

### DIFF
--- a/.waffle.json
+++ b/.waffle.json
@@ -9,7 +9,8 @@
           "evm.deployedBytecode.object",
           "abi",
           "evm.bytecode.sourceMap",
-          "evm.deployedBytecode.sourceMap"
+          "evm.deployedBytecode.sourceMap",
+          "metadata"
         ],
         "": ["ast"]
       }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Uniswap V2
+# Etcswap V2
 
 [![Actions Status](https://github.com/Uniswap/uniswap-v2-core/workflows/CI/badge.svg)](https://github.com/Uniswap/uniswap-v2-core/actions)
 [![Version](https://img.shields.io/npm/v/@uniswap/v2-core)](https://www.npmjs.com/package/@uniswap/v2-core)
 
-In-depth documentation on Uniswap V2 is available at [uniswap.org](https://uniswap.org/docs).
+In-depth documentation on Etcswap V2 is available at [uniswap.org](https://uniswap.org/docs).
 
 The built contract artifacts can be browsed via [unpkg.com](https://unpkg.com/browse/@uniswap/v2-core@latest/).
 

--- a/contracts/EtcswapV2ERC20.sol
+++ b/contracts/EtcswapV2ERC20.sol
@@ -4,10 +4,10 @@
 
 pragma solidity =0.5.16;
 
-import './interfaces/IUniswapV2ERC20.sol';
+import './interfaces/IEtcswapV2ERC20.sol';
 import './libraries/SafeMath.sol';
 
-contract UniswapV2ERC20 is IUniswapV2ERC20 {
+contract EtcswapV2ERC20 is IEtcswapV2ERC20 {
     using SafeMath for uint;
 
     string public constant name = 'ETC Swap V2';
@@ -83,7 +83,7 @@ contract UniswapV2ERC20 is IUniswapV2ERC20 {
     }
 
     function permit(address owner, address spender, uint value, uint deadline, uint8 v, bytes32 r, bytes32 s) external {
-        require(deadline >= block.timestamp, 'UniswapV2: EXPIRED');
+        require(deadline >= block.timestamp, 'EtcswapV2: EXPIRED');
         bytes32 digest = keccak256(
             abi.encodePacked(
                 '\x19\x01',
@@ -92,7 +92,7 @@ contract UniswapV2ERC20 is IUniswapV2ERC20 {
             )
         );
         address recoveredAddress = ecrecover(digest, v, r, s);
-        require(recoveredAddress != address(0) && recoveredAddress == owner, 'UniswapV2: INVALID_SIGNATURE');
+        require(recoveredAddress != address(0) && recoveredAddress == owner, 'EtcswapV2: INVALID_SIGNATURE');
         _approve(owner, spender, value);
     }
 }

--- a/contracts/EtcswapV2Factory.sol
+++ b/contracts/EtcswapV2Factory.sol
@@ -4,14 +4,14 @@
 
 pragma solidity =0.5.16;
 
-import './interfaces/IUniswapV2Factory.sol';
-import './UniswapV2Pair.sol';
+import './interfaces/IEtcswapV2Factory.sol';
+import './EtcswapV2Pair.sol';
 
-contract UniswapV2Factory is IUniswapV2Factory {
+contract EtcswapV2Factory is IEtcswapV2Factory {
     address public feeTo;
     address public feeToSetter;
 
-    bytes32 public constant INIT_CODE_HASH = keccak256(abi.encodePacked(type(UniswapV2Pair).creationCode));
+    bytes32 public constant INIT_CODE_HASH = keccak256(abi.encodePacked(type(EtcswapV2Pair).creationCode));
 
     mapping(address => mapping(address => address)) public getPair;
     address[] public allPairs;
@@ -27,16 +27,16 @@ contract UniswapV2Factory is IUniswapV2Factory {
     }
 
     function createPair(address tokenA, address tokenB) external returns (address pair) {
-        require(tokenA != tokenB, 'UniswapV2: IDENTICAL_ADDRESSES');
+        require(tokenA != tokenB, 'EtcswapV2: IDENTICAL_ADDRESSES');
         (address token0, address token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
-        require(token0 != address(0), 'UniswapV2: ZERO_ADDRESS');
-        require(getPair[token0][token1] == address(0), 'UniswapV2: PAIR_EXISTS'); // single check is sufficient
-        bytes memory bytecode = type(UniswapV2Pair).creationCode;
+        require(token0 != address(0), 'EtcswapV2: ZERO_ADDRESS');
+        require(getPair[token0][token1] == address(0), 'EtcswapV2: PAIR_EXISTS'); // single check is sufficient
+        bytes memory bytecode = type(EtcswapV2Pair).creationCode;
         bytes32 salt = keccak256(abi.encodePacked(token0, token1));
         assembly {
             pair := create2(0, add(bytecode, 32), mload(bytecode), salt)
         }
-        IUniswapV2Pair(pair).initialize(token0, token1);
+        IEtcswapV2Pair(pair).initialize(token0, token1);
         getPair[token0][token1] = pair;
         getPair[token1][token0] = pair; // populate mapping in the reverse direction
         allPairs.push(pair);
@@ -44,12 +44,12 @@ contract UniswapV2Factory is IUniswapV2Factory {
     }
 
     function setFeeTo(address _feeTo) external {
-        require(msg.sender == feeToSetter, 'UniswapV2: FORBIDDEN');
+        require(msg.sender == feeToSetter, 'EtcswapV2: FORBIDDEN');
         feeTo = _feeTo;
     }
 
     function setFeeToSetter(address _feeToSetter) external {
-        require(msg.sender == feeToSetter, 'UniswapV2: FORBIDDEN');
+        require(msg.sender == feeToSetter, 'EtcswapV2: FORBIDDEN');
         feeToSetter = _feeToSetter;
     }
 }

--- a/contracts/EtcswapV2Pair.sol
+++ b/contracts/EtcswapV2Pair.sol
@@ -1,14 +1,14 @@
 pragma solidity =0.5.16;
 
-import './interfaces/IUniswapV2Pair.sol';
-import './UniswapV2ERC20.sol';
+import './interfaces/IEtcswapV2Pair.sol';
+import './EtcswapV2ERC20.sol';
 import './libraries/Math.sol';
 import './libraries/UQ112x112.sol';
 import './interfaces/IERC20.sol';
-import './interfaces/IUniswapV2Factory.sol';
-import './interfaces/IUniswapV2Callee.sol';
+import './interfaces/IEtcswapV2Factory.sol';
+import './interfaces/IEtcswapV2Callee.sol';
 
-contract UniswapV2Pair is IUniswapV2Pair, UniswapV2ERC20 {
+contract EtcswapV2Pair is IEtcswapV2Pair, EtcswapV2ERC20 {
     using SafeMath  for uint;
     using UQ112x112 for uint224;
 
@@ -29,7 +29,7 @@ contract UniswapV2Pair is IUniswapV2Pair, UniswapV2ERC20 {
 
     uint private unlocked = 1;
     modifier lock() {
-        require(unlocked == 1, 'UniswapV2: LOCKED');
+        require(unlocked == 1, 'EtcswapV2: LOCKED');
         unlocked = 0;
         _;
         unlocked = 1;
@@ -43,7 +43,7 @@ contract UniswapV2Pair is IUniswapV2Pair, UniswapV2ERC20 {
 
     function _safeTransfer(address token, address to, uint value) private {
         (bool success, bytes memory data) = token.call(abi.encodeWithSelector(SELECTOR, to, value));
-        require(success && (data.length == 0 || abi.decode(data, (bool))), 'UniswapV2: TRANSFER_FAILED');
+        require(success && (data.length == 0 || abi.decode(data, (bool))), 'EtcswapV2: TRANSFER_FAILED');
     }
 
     event Mint(address indexed sender, uint amount0, uint amount1);
@@ -64,14 +64,14 @@ contract UniswapV2Pair is IUniswapV2Pair, UniswapV2ERC20 {
 
     // called once by the factory at time of deployment
     function initialize(address _token0, address _token1) external {
-        require(msg.sender == factory, 'UniswapV2: FORBIDDEN'); // sufficient check
+        require(msg.sender == factory, 'EtcswapV2: FORBIDDEN'); // sufficient check
         token0 = _token0;
         token1 = _token1;
     }
 
     // update reserves and, on the first call per block, price accumulators
     function _update(uint balance0, uint balance1, uint112 _reserve0, uint112 _reserve1) private {
-        require(balance0 <= uint112(-1) && balance1 <= uint112(-1), 'UniswapV2: OVERFLOW');
+        require(balance0 <= uint112(-1) && balance1 <= uint112(-1), 'EtcswapV2: OVERFLOW');
         uint32 blockTimestamp = uint32(block.timestamp % 2**32);
         uint32 timeElapsed = blockTimestamp - blockTimestampLast; // overflow is desired
         if (timeElapsed > 0 && _reserve0 != 0 && _reserve1 != 0) {
@@ -87,7 +87,7 @@ contract UniswapV2Pair is IUniswapV2Pair, UniswapV2ERC20 {
 
     // if fee is on, mint liquidity equivalent to 1/6th of the growth in sqrt(k)
     function _mintFee(uint112 _reserve0, uint112 _reserve1) private returns (bool feeOn) {
-        address feeTo = IUniswapV2Factory(factory).feeTo();
+        address feeTo = IEtcswapV2Factory(factory).feeTo();
         feeOn = feeTo != address(0);
         uint _kLast = kLast; // gas savings
         if (feeOn) {
@@ -122,7 +122,7 @@ contract UniswapV2Pair is IUniswapV2Pair, UniswapV2ERC20 {
         } else {
             liquidity = Math.min(amount0.mul(_totalSupply) / _reserve0, amount1.mul(_totalSupply) / _reserve1);
         }
-        require(liquidity > 0, 'UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED');
+        require(liquidity > 0, 'EtcswapV2: INSUFFICIENT_LIQUIDITY_MINTED');
         _mint(to, liquidity);
 
         _update(balance0, balance1, _reserve0, _reserve1);
@@ -143,7 +143,7 @@ contract UniswapV2Pair is IUniswapV2Pair, UniswapV2ERC20 {
         uint _totalSupply = totalSupply; // gas savings, must be defined here since totalSupply can update in _mintFee
         amount0 = liquidity.mul(balance0) / _totalSupply; // using balances ensures pro-rata distribution
         amount1 = liquidity.mul(balance1) / _totalSupply; // using balances ensures pro-rata distribution
-        require(amount0 > 0 && amount1 > 0, 'UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED');
+        require(amount0 > 0 && amount1 > 0, 'EtcswapV2: INSUFFICIENT_LIQUIDITY_BURNED');
         _burn(address(this), liquidity);
         _safeTransfer(_token0, to, amount0);
         _safeTransfer(_token1, to, amount1);
@@ -157,29 +157,29 @@ contract UniswapV2Pair is IUniswapV2Pair, UniswapV2ERC20 {
 
     // this low-level function should be called from a contract which performs important safety checks
     function swap(uint amount0Out, uint amount1Out, address to, bytes calldata data) external lock {
-        require(amount0Out > 0 || amount1Out > 0, 'UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT');
+        require(amount0Out > 0 || amount1Out > 0, 'EtcswapV2: INSUFFICIENT_OUTPUT_AMOUNT');
         (uint112 _reserve0, uint112 _reserve1,) = getReserves(); // gas savings
-        require(amount0Out < _reserve0 && amount1Out < _reserve1, 'UniswapV2: INSUFFICIENT_LIQUIDITY');
+        require(amount0Out < _reserve0 && amount1Out < _reserve1, 'EtcswapV2: INSUFFICIENT_LIQUIDITY');
 
         uint balance0;
         uint balance1;
         { // scope for _token{0,1}, avoids stack too deep errors
         address _token0 = token0;
         address _token1 = token1;
-        require(to != _token0 && to != _token1, 'UniswapV2: INVALID_TO');
+        require(to != _token0 && to != _token1, 'EtcswapV2: INVALID_TO');
         if (amount0Out > 0) _safeTransfer(_token0, to, amount0Out); // optimistically transfer tokens
         if (amount1Out > 0) _safeTransfer(_token1, to, amount1Out); // optimistically transfer tokens
-        if (data.length > 0) IUniswapV2Callee(to).uniswapV2Call(msg.sender, amount0Out, amount1Out, data);
+        if (data.length > 0) IEtcswapV2Callee(to).etcswapV2Call(msg.sender, amount0Out, amount1Out, data);
         balance0 = IERC20(_token0).balanceOf(address(this));
         balance1 = IERC20(_token1).balanceOf(address(this));
         }
         uint amount0In = balance0 > _reserve0 - amount0Out ? balance0 - (_reserve0 - amount0Out) : 0;
         uint amount1In = balance1 > _reserve1 - amount1Out ? balance1 - (_reserve1 - amount1Out) : 0;
-        require(amount0In > 0 || amount1In > 0, 'UniswapV2: INSUFFICIENT_INPUT_AMOUNT');
+        require(amount0In > 0 || amount1In > 0, 'EtcswapV2: INSUFFICIENT_INPUT_AMOUNT');
         { // scope for reserve{0,1}Adjusted, avoids stack too deep errors
         uint balance0Adjusted = balance0.mul(1000).sub(amount0In.mul(3));
         uint balance1Adjusted = balance1.mul(1000).sub(amount1In.mul(3));
-        require(balance0Adjusted.mul(balance1Adjusted) >= uint(_reserve0).mul(_reserve1).mul(1000**2), 'UniswapV2: K');
+        require(balance0Adjusted.mul(balance1Adjusted) >= uint(_reserve0).mul(_reserve1).mul(1000**2), 'EtcswapV2: K');
         }
 
         _update(balance0, balance1, _reserve0, _reserve1);

--- a/contracts/interfaces/IEtcswapV2Callee.sol
+++ b/contracts/interfaces/IEtcswapV2Callee.sol
@@ -1,0 +1,5 @@
+pragma solidity >=0.5.0;
+
+interface IEtcswapV2Callee {
+    function etcswapV2Call(address sender, uint amount0, uint amount1, bytes calldata data) external;
+}

--- a/contracts/interfaces/IEtcswapV2ERC20.sol
+++ b/contracts/interfaces/IEtcswapV2ERC20.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.5.0;
 
-interface IUniswapV2ERC20 {
+interface IEtcswapV2ERC20 {
     event Approval(address indexed owner, address indexed spender, uint value);
     event Transfer(address indexed from, address indexed to, uint value);
 

--- a/contracts/interfaces/IEtcswapV2Factory.sol
+++ b/contracts/interfaces/IEtcswapV2Factory.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.5.0;
 
-interface IUniswapV2Factory {
+interface IEtcswapV2Factory {
     event PairCreated(address indexed token0, address indexed token1, address pair, uint);
 
     function feeTo() external view returns (address);

--- a/contracts/interfaces/IEtcswapV2Pair.sol
+++ b/contracts/interfaces/IEtcswapV2Pair.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.5.0;
 
-interface IUniswapV2Pair {
+interface IEtcswapV2Pair {
     event Approval(address indexed owner, address indexed spender, uint value);
     event Transfer(address indexed from, address indexed to, uint value);
 

--- a/contracts/interfaces/IUniswapV2Callee.sol
+++ b/contracts/interfaces/IUniswapV2Callee.sol
@@ -1,5 +1,0 @@
-pragma solidity >=0.5.0;
-
-interface IUniswapV2Callee {
-    function uniswapV2Call(address sender, uint amount0, uint amount1, bytes calldata data) external;
-}

--- a/contracts/test/ERC20.sol
+++ b/contracts/test/ERC20.sol
@@ -1,8 +1,8 @@
 pragma solidity =0.5.16;
 
-import '../UniswapV2ERC20.sol';
+import '../EtcswapV2ERC20.sol';
 
-contract ERC20 is UniswapV2ERC20 {
+contract ERC20 is EtcswapV2ERC20 {
     constructor(uint _totalSupply) public {
         _mint(msg.sender, _totalSupply);
     }

--- a/package.json
+++ b/package.json
@@ -1,14 +1,16 @@
 {
   "name": "@uniswap/v2-core",
-  "version": "1.0.0-beta.3",
-  "files": [
-    "contracts",
-    "build"
-  ],
+  "description": "Core contracts for the UniswapV2 protocol",
+  "version": "1.0.0-beta.4",
+  "homepage": "https://uniswap.org",
   "repository": {
     "type": "git",
     "url": "https://github.com/Uniswap/uniswap-v2-core"
   },
+  "files": [
+    "contracts",
+    "build"
+  ],
   "engines": {
     "node": ">=10"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/v2-core",
-  "description": "Core contracts for the UniswapV2 protocol",
+  "description": "🎛 Core contracts for the UniswapV2 protocol",
   "version": "1.0.0",
   "homepage": "https://uniswap.org",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uniswap/v2-core",
   "description": "Core contracts for the UniswapV2 protocol",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0",
   "homepage": "https://uniswap.org",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uniswap/v2-core",
   "description": "🎛 Core contracts for the UniswapV2 protocol",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://uniswap.org",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,13 @@
     "type": "git",
     "url": "https://github.com/Uniswap/uniswap-v2-core"
   },
+  "keywords": [
+    "uniswap",
+    "ethereum",
+    "v2",
+    "core",
+    "uniswap-v2"
+  ],
   "files": [
     "contracts",
     "build"

--- a/package.json
+++ b/package.json
@@ -1,18 +1,19 @@
 {
-  "name": "@uniswap/v2-core",
-  "description": "🎛 Core contracts for the UniswapV2 protocol",
+  "name": "@etcswap/v2-core",
+  "description": "🎛 Core contracts for the EtcswapV2 protocol",
   "version": "1.0.1",
-  "homepage": "https://uniswap.org",
+  "homepage": "https://etcswap.org",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Uniswap/uniswap-v2-core"
+    "url": "https://github.com/etcswap/v2-core"
   },
   "keywords": [
-    "uniswap",
-    "ethereum",
+    "etcswap",
+    "ethereum classic",
+    "etc",
     "v2",
     "core",
-    "uniswap-v2"
+    "etcswap-v2"
   ],
   "files": [
     "contracts",

--- a/test/EtcswapV2ERC20.spec.ts
+++ b/test/EtcswapV2ERC20.spec.ts
@@ -14,7 +14,7 @@ chai.use(solidity)
 const TOTAL_SUPPLY = expandTo18Decimals(10000)
 const TEST_AMOUNT = expandTo18Decimals(10)
 
-describe('UniswapV2ERC20', () => {
+describe('EtcswapV2ERC20', () => {
   const provider = new MockProvider({
     hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',

--- a/test/EtcswapV2Factory.spec.ts
+++ b/test/EtcswapV2Factory.spec.ts
@@ -7,7 +7,7 @@ import { solidity, MockProvider, createFixtureLoader } from 'ethereum-waffle'
 import { getCreate2Address } from './shared/utilities'
 import { factoryFixture } from './shared/fixtures'
 
-import UniswapV2Pair from '../build/UniswapV2Pair.json'
+import EtcswapV2Pair from '../build/EtcswapV2Pair.json'
 
 chai.use(solidity)
 
@@ -16,7 +16,7 @@ const TEST_ADDRESSES: [string, string] = [
   '0x2000000000000000000000000000000000000000'
 ]
 
-describe('UniswapV2Factory', () => {
+describe('EtcswapV2Factory', () => {
   const provider = new MockProvider({
     hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
@@ -38,20 +38,20 @@ describe('UniswapV2Factory', () => {
   })
 
   async function createPair(tokens: [string, string]) {
-    const bytecode = `0x${UniswapV2Pair.evm.bytecode.object}`
+    const bytecode = `0x${EtcswapV2Pair.evm.bytecode.object}`
     const create2Address = getCreate2Address(factory.address, tokens, bytecode)
     await expect(factory.createPair(...tokens))
       .to.emit(factory, 'PairCreated')
       .withArgs(TEST_ADDRESSES[0], TEST_ADDRESSES[1], create2Address, bigNumberify(1))
 
-    await expect(factory.createPair(...tokens)).to.be.reverted // UniswapV2: PAIR_EXISTS
-    await expect(factory.createPair(...tokens.slice().reverse())).to.be.reverted // UniswapV2: PAIR_EXISTS
+    await expect(factory.createPair(...tokens)).to.be.reverted // EtcswapV2: PAIR_EXISTS
+    await expect(factory.createPair(...tokens.slice().reverse())).to.be.reverted // EtcswapV2: PAIR_EXISTS
     expect(await factory.getPair(...tokens)).to.eq(create2Address)
     expect(await factory.getPair(...tokens.slice().reverse())).to.eq(create2Address)
     expect(await factory.allPairs(0)).to.eq(create2Address)
     expect(await factory.allPairsLength()).to.eq(1)
 
-    const pair = new Contract(create2Address, JSON.stringify(UniswapV2Pair.abi), provider)
+    const pair = new Contract(create2Address, JSON.stringify(EtcswapV2Pair.abi), provider)
     expect(await pair.factory()).to.eq(factory.address)
     expect(await pair.token0()).to.eq(TEST_ADDRESSES[0])
     expect(await pair.token1()).to.eq(TEST_ADDRESSES[1])
@@ -68,19 +68,19 @@ describe('UniswapV2Factory', () => {
   it('createPair:gas', async () => {
     const tx = await factory.createPair(...TEST_ADDRESSES)
     const receipt = await tx.wait()
-    expect(receipt.gasUsed).to.eq(2499878)
+    expect(receipt.gasUsed).to.eq(2512920)
   })
 
   it('setFeeTo', async () => {
-    await expect(factory.connect(other).setFeeTo(other.address)).to.be.revertedWith('UniswapV2: FORBIDDEN')
+    await expect(factory.connect(other).setFeeTo(other.address)).to.be.revertedWith('EtcswapV2: FORBIDDEN')
     await factory.setFeeTo(wallet.address)
     expect(await factory.feeTo()).to.eq(wallet.address)
   })
 
   it('setFeeToSetter', async () => {
-    await expect(factory.connect(other).setFeeToSetter(other.address)).to.be.revertedWith('UniswapV2: FORBIDDEN')
+    await expect(factory.connect(other).setFeeToSetter(other.address)).to.be.revertedWith('EtcswapV2: FORBIDDEN')
     await factory.setFeeToSetter(other.address)
     expect(await factory.feeToSetter()).to.eq(other.address)
-    await expect(factory.setFeeToSetter(wallet.address)).to.be.revertedWith('UniswapV2: FORBIDDEN')
+    await expect(factory.setFeeToSetter(wallet.address)).to.be.revertedWith('EtcswapV2: FORBIDDEN')
   })
 })

--- a/test/UniswapV2Pair.spec.ts
+++ b/test/UniswapV2Pair.spec.ts
@@ -15,7 +15,7 @@ const overrides = {
   gasLimit: 9999999
 }
 
-describe('UniswapV2Pair', () => {
+describe('EtcswapV2Pair', () => {
   const provider = new MockProvider({
     hardfork: 'istanbul',
     mnemonic: 'horn horn horn horn horn horn horn horn horn horn horn horn',
@@ -84,7 +84,7 @@ describe('UniswapV2Pair', () => {
       await addLiquidity(token0Amount, token1Amount)
       await token0.transfer(pair.address, swapAmount)
       await expect(pair.swap(0, expectedOutputAmount.add(1), wallet.address, '0x', overrides)).to.be.revertedWith(
-        'UniswapV2: K'
+        'EtcswapV2: K'
       )
       await pair.swap(0, expectedOutputAmount, wallet.address, '0x', overrides)
     })
@@ -102,7 +102,7 @@ describe('UniswapV2Pair', () => {
       await addLiquidity(token0Amount, token1Amount)
       await token0.transfer(pair.address, inputAmount)
       await expect(pair.swap(outputAmount.add(1), 0, wallet.address, '0x', overrides)).to.be.revertedWith(
-        'UniswapV2: K'
+        'EtcswapV2: K'
       )
       await pair.swap(outputAmount, 0, wallet.address, '0x', overrides)
     })

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -5,8 +5,8 @@ import { deployContract } from 'ethereum-waffle'
 import { expandTo18Decimals } from './utilities'
 
 import ERC20 from '../../build/ERC20.json'
-import UniswapV2Factory from '../../build/UniswapV2Factory.json'
-import UniswapV2Pair from '../../build/UniswapV2Pair.json'
+import EtcswapV2Factory from '../../build/EtcswapV2Factory.json'
+import EtcswapV2Pair from '../../build/EtcswapV2Pair.json'
 
 interface FactoryFixture {
   factory: Contract
@@ -17,7 +17,7 @@ const overrides = {
 }
 
 export async function factoryFixture(_: Web3Provider, [wallet]: Wallet[]): Promise<FactoryFixture> {
-  const factory = await deployContract(wallet, UniswapV2Factory, [wallet.address], overrides)
+  const factory = await deployContract(wallet, EtcswapV2Factory, [wallet.address], overrides)
   return { factory }
 }
 
@@ -35,7 +35,7 @@ export async function pairFixture(provider: Web3Provider, [wallet]: Wallet[]): P
 
   await factory.createPair(tokenA.address, tokenB.address, overrides)
   const pairAddress = await factory.getPair(tokenA.address, tokenB.address)
-  const pair = new Contract(pairAddress, JSON.stringify(UniswapV2Pair.abi), provider).connect(wallet)
+  const pair = new Contract(pairAddress, JSON.stringify(EtcswapV2Pair.abi), provider).connect(wallet)
 
   const token0Address = (await pair.token0()).address
   const token0 = tokenA.address === token0Address ? tokenA : tokenB


### PR DESCRIPTION
- Renames all contracts and functions to ETCSwap
- Tests pass 
- TODO: Fix links in README.md
- NOTE: Expected gas in EtcswapV2Factory.spec.tsneeded an update. See diff for details

Test Results
----------------
yarn run v1.22.18
$ yarn compile
$ yarn clean
$ rimraf ./build/
$ waffle .waffle.json
$ mocha


  EtcswapV2ERC20
    ✓ name, symbol, decimals, totalSupply, balanceOf, DOMAIN_SEPARATOR, PERMIT_TYPEHASH (229ms)
    ✓ approve (200ms)
    ✓ transfer (226ms)
    ✓ transfer:fail (90ms)
    ✓ transferFrom (247ms)
    ✓ transferFrom:max (152ms)
    ✓ permit (129ms)

  EtcswapV2Factory
    ✓ feeTo, feeToSetter, allPairsLength
    ✓ createPair (250ms)
    ✓ createPair:reverse (284ms)
    ✓ createPair:gas (101ms)
    ✓ setFeeTo (68ms)
    ✓ setFeeToSetter (77ms)

  EtcswapV2Pair
    ✓ mint (228ms)
    ✓ getInputPrice:0 (268ms)
    ✓ getInputPrice:1 (286ms)
    ✓ getInputPrice:2 (250ms)
    ✓ getInputPrice:3 (257ms)
    ✓ getInputPrice:4 (245ms)
    ✓ getInputPrice:5 (235ms)
    ✓ getInputPrice:6 (253ms)
    ✓ optimistic:0 (237ms)
    ✓ optimistic:1 (230ms)
    ✓ optimistic:2 (226ms)
    ✓ optimistic:3 (244ms)
    ✓ swap:token0 (268ms)
    ✓ swap:token1 (261ms)
    ✓ swap:gas (252ms)
    ✓ burn (279ms)
    ✓ price{0,1}CumulativeLast (330ms)
    ✓ feeTo:off (304ms)
    ✓ feeTo:on (366ms)


  32 passing (9s)

Done in 21.54s.